### PR TITLE
fix(core): fixing ability for empty property scans inbetween used sca…

### DIFF
--- a/pyscan/measurement/run_info.py
+++ b/pyscan/measurement/run_info.py
@@ -88,6 +88,20 @@ class RunInfo(ItemAttribute):
         if num_av_scans > 1:
             assert False, "More than one average scan is not allowed"
 
+        # make sure there are no empty scans inbetween used scans.
+        used_scan_found = False
+        scans = self.scans
+        for i in range(len(scans)):
+            count_down = len(scans) - i - 1
+            if used_scan_found is False:
+                if not (isinstance(scans[count_down], PropertyScan) and len(scans[count_down].input_dict) == 0):
+                    used_scan_found = True
+                    used_scan_index = count_down
+            else:
+                assert not (isinstance(scans[count_down], PropertyScan) and len(scans[count_down].input_dict) == 0), \
+                    (f"Found empty PropertyScan (scan{count_down}) below used scan (scan{used_scan_index}).\n"
+                     + "Scans must be populated in sequential order.")
+
     @property
     def scans(self):
         ''' Returns array of all scans

--- a/test/measurement/test_run_info.py
+++ b/test/measurement/test_run_info.py
@@ -3,6 +3,7 @@ Pytest functions to test the Runinfo class
 '''
 
 import pyscan as ps
+import pytest
 
 
 #  ######## need to add tests for runinfo's different @property definitions.
@@ -97,3 +98,10 @@ def test_init_from_noparams():
         check_attribute(runinfo=init_runinfo, attribute=init_runinfo.verbose, attribute_name='verbose', expected=False)
 
     check_runinfo_attributes()
+
+    init_runinfo.scan0 = ps.PropertyScan({'v1': ps.drange(0, 0.1, 0.1)}, 'voltage')
+    init_runinfo.scan1 = ps.PropertyScan({'v2': ps.drange(0, 0.1, 0.1)}, 'voltage')
+    init_runinfo.check()
+    with pytest.raises(Exception):
+        init_runinfo.scan3 = ps.PropertyScan({'v3': ps.drange(0, 0.1, 0.1)}, 'voltage')
+        init_runinfo.check()


### PR DESCRIPTION
…ns. Now adding a check to block this. Scans must be populated in sequential order.