### PR TITLE
fix(driver): doc string if not found returns blank.  If multiple, tak…

### DIFF
--- a/pyscan/drivers/instrument_driver.py
+++ b/pyscan/drivers/instrument_driver.py
@@ -433,13 +433,22 @@ class InstrumentDriver(ItemAttribute):
 
         doc = self.__doc__.split('\n')
 
-        r = re.compile("    {} :".format(prop_name))
-        match = list(filter(r.match, doc))
+        r = "    {} :".format(prop_name)
 
-        assert len(match) > 0, "No matches for {} documentation".format(prop_name)
-        assert len(match) == 1, "Too many matches for {} documentation".format(prop_name)
-        match = match[0]
+        def find_match(str):
+            if r in str:
+                return True
+            else:
+                return False
 
+        match = list(filter(find_match, doc))
+
+        assert not len(match) > 1, "Too many matches for {} documentation".format(prop_name)
+
+        if len(match) == 0:
+            match = ''
+        else:
+            match = match[0]
         for i, string in enumerate(doc):
             if string == match:
                 break


### PR DESCRIPTION
…es first